### PR TITLE
アサインする人の選択ロジックを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # rspec failure tracking
 .rspec_status
+
+vendor/bundle

--- a/lib/pghub/auto_assign.rb
+++ b/lib/pghub/auto_assign.rb
@@ -66,8 +66,8 @@ module Pghub
           team_members = all_members[team.to_sym]
           raise TooManyNumOfMembersError, team if number > team_members.length
 
+          team_members.delete(opened_pr_user)
           selected_members = team_members.sample(number)
-          selected_members.delete(opened_pr_user)
           members += selected_members
         end
 

--- a/lib/pghub/auto_assign/version.rb
+++ b/lib/pghub/auto_assign/version.rb
@@ -1,5 +1,5 @@
 module Pghub
   module AutoAssign
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end

--- a/pghub-auto_assign.gemspec
+++ b/pghub-auto_assign.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "pghub-base", "~> 1.1.0"
+  spec.add_dependency "pghub-base", ">= 1.1.1"
 end


### PR DESCRIPTION
# WHAT
- PRした人が、チームごとに設定した人数の中に含まれてしまうバグ
- assignee(reviewer)を選択するときのロジックを修正
- 依存しているgemをvendor/bundleディレクトリに保存するように変更
- issueにも動作を実行してしまう問題を修正したpghub-baseにdependencyを変更